### PR TITLE
Support ignore patterns for requests library

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,6 @@ OPENTRACING PYTHON UTILS
 .. image:: https://codecov.io/gh/zalando-zmon/opentracing-utils/branch/master/graph/badge.svg
   :target: https://codecov.io/gh/zalando-zmon/opentracing-utils
   :alt: Code coverage
-
 .. image:: https://img.shields.io/badge/OpenTracing-enabled-blue.svg
    :target: http://opentracing.io
    :alt: OpenTracing enabled
@@ -354,6 +353,13 @@ For tracing `requests <https://github.com/requests/requests>`_ client library fo
 
     # You can also mask URL path parameters (e.g. http://hostname/1 will be http://hostname/??/)
     # trace_requests(mask_url_path=True)
+
+    # The library patches the requests library send functionality. This causes
+    # all requests to propagate the span id's in the headers. Sometimes this is
+    # undesireable so it's also possible to avoid tracing specific URL's or
+    # endpoints. trace_requests accepts a list of regex patterns and matches the
+    # request.url against these patterns, ignoring traces if any pattern matches.
+    # trace_requests(ignore_patterns=[r".*hostname/endpoint"]
 
     import requests
 

--- a/opentracing_utils/libs/_requests.py
+++ b/opentracing_utils/libs/_requests.py
@@ -27,7 +27,8 @@ OPERATION_NAME_PREFIX = 'requests.send'
 logger = logging.getLogger(__name__)
 
 
-def trace_requests(default_tags=None, set_error_tag=True, mask_url_query=True, mask_url_path=False, ignore_patterns=[]):
+def trace_requests(default_tags=None, set_error_tag=True, mask_url_query=True,
+                   mask_url_path=False, ignore_url_patterns=None):
     """Patch requests library with OpenTracing support.
 
     :param default_tags: Default span tags to included with every outgoing request.
@@ -42,14 +43,14 @@ def trace_requests(default_tags=None, set_error_tag=True, mask_url_query=True, m
     :param mask_url_path: Mask URL path.
     :type mask_url_path: bool
 
-    :param ignore_patterns: Ignore tracing for any URL's that match entries in this list
-    :type ignore_patterns: list
+    :param ignore_url_patterns: Ignore tracing for any URL's that match entries in this list
+    :type ignore_url_patterns: list
     """
     @trace(pass_span=True, tags=default_tags)
     def requests_send_wrapper(self, request, **kwargs):
-        if any(re.match(pattern, request.url) for pattern in ignore_patterns):
-            logger.warn("An ignore pattern matched, ignoring traces")
-            return __requests_http_send(self, request, **kwargs)
+        if ignore_url_patterns is not None:
+            if any(re.match(pattern, request.url) for pattern in ignore_url_patterns):
+                return __requests_http_send(self, request, **kwargs)
 
         op_name = '{}.{}'.format(OPERATION_NAME_PREFIX, request.method)
 

--- a/opentracing_utils/libs/_requests.py
+++ b/opentracing_utils/libs/_requests.py
@@ -18,7 +18,7 @@ from opentracing import Format
 from opentracing.ext import tags as ot_tags
 
 from opentracing_utils.decorators import trace
-from opentracing_utils.span import get_span_from_kwargs, remove_span_from_kwargs
+from opentracing_utils.span import get_span_from_kwargs
 from opentracing_utils.common import sanitize_url
 
 
@@ -49,7 +49,7 @@ def trace_requests(default_tags=None, set_error_tag=True, mask_url_query=True, m
     def requests_send_wrapper(self, request, **kwargs):
         if any(re.match(pattern, request.url) for pattern in ignore_patterns):
             logger.warn("An ignore pattern matched, ignoring traces")
-            return __requests_http_send(self, request, **remove_span_from_kwargs(**kwargs))
+            return __requests_http_send(self, request, **kwargs)
 
         op_name = '{}.{}'.format(OPERATION_NAME_PREFIX, request.method)
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -23,7 +23,7 @@ CUSTOM_HEADER = 'X-CUSTOM'
 CUSTOM_HEADER_VALUE = '123'
 
 
-def assert_send_reuqest_mock(resp):
+def assert_send_request_mock(resp):
 
     def send_request_mock(self, request, **kwargs):
         assert 'ot-tracer-traceid' in request.headers
@@ -52,7 +52,7 @@ def test_trace_requests(monkeypatch, status_code):
     resp.status_code = status_code
     resp.url = URL
 
-    monkeypatch.setattr('opentracing_utils.libs._requests.__requests_http_send', assert_send_reuqest_mock(resp))
+    monkeypatch.setattr('opentracing_utils.libs._requests.__requests_http_send', assert_send_request_mock(resp))
 
     @trace()
     def f1():
@@ -111,7 +111,7 @@ def test_trace_requests_with_tags(monkeypatch):
 
     trace_requests(default_tags={'tag1': 'value1'})
 
-    monkeypatch.setattr('opentracing_utils.libs._requests.__requests_http_send', assert_send_reuqest_mock(resp))
+    monkeypatch.setattr('opentracing_utils.libs._requests.__requests_http_send', assert_send_request_mock(resp))
 
     @trace()
     def f1():
@@ -155,7 +155,7 @@ def test_trace_requests_no_error_tag(monkeypatch):
 
     trace_requests(set_error_tag=False)
 
-    monkeypatch.setattr('opentracing_utils.libs._requests.__requests_http_send', assert_send_reuqest_mock(resp))
+    monkeypatch.setattr('opentracing_utils.libs._requests.__requests_http_send', assert_send_request_mock(resp))
 
     recorder = Recorder()
     t = BasicTracer(recorder=recorder)
@@ -186,7 +186,7 @@ def test_trace_requests_session(monkeypatch):
     resp.status_code = 200
     resp.url = URL
 
-    monkeypatch.setattr('opentracing_utils.libs._requests.__requests_http_send', assert_send_reuqest_mock(resp))
+    monkeypatch.setattr('opentracing_utils.libs._requests.__requests_http_send', assert_send_request_mock(resp))
 
     recorder = Recorder()
     t = BasicTracer(recorder=recorder)
@@ -220,7 +220,7 @@ def test_trace_requests_nested(monkeypatch):
     resp.status_code = 200
     resp.url = URL
 
-    monkeypatch.setattr('opentracing_utils.libs._requests.__requests_http_send', assert_send_reuqest_mock(resp))
+    monkeypatch.setattr('opentracing_utils.libs._requests.__requests_http_send', assert_send_request_mock(resp))
 
     recorder = Recorder()
     t = BasicTracer(recorder=recorder)
@@ -303,7 +303,7 @@ def test_trace_requests_no_parent_span(monkeypatch):
     resp.status_code = 200
     resp.url = URL
 
-    monkeypatch.setattr('opentracing_utils.libs._requests.__requests_http_send', assert_send_reuqest_mock(resp))
+    monkeypatch.setattr('opentracing_utils.libs._requests.__requests_http_send', assert_send_request_mock(resp))
 
     recorder = Recorder()
     t = BasicTracer(recorder=recorder)

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -88,12 +88,12 @@ def test_trace_requests(monkeypatch, status_code):
         assert recorder.spans[0].tags['error'] is True
 
 
-def test_trace_requests_with_ignore_pattern(monkeypatch):
+def test_trace_requests_with_ignore_url_pattern(monkeypatch):
     resp = Response()
     resp.status_code = 200
     resp.url = URL
 
-    trace_requests(ignore_patterns=[r".*{}.*".format(URL)])
+    trace_requests(ignore_url_patterns=[r".*{}.*".format(URL)])
 
     monkeypatch.setattr(
        'opentracing_utils.libs._requests.__requests_http_send',


### PR DESCRIPTION
In some cases the user might want to avoid tracing of specific URL's or
endpoints. This commit adds a new parameter to the
`trace_requests()`-function to set a list of URL patterns to ignore when
a request is made. `ignore_patterns` is a keyword argument and should
contain python regex patterns that can be used for matching. For
example, ignore tracing requests to a sidecar container running in
localhost:4040:


    trace_requests(ignore_patterns=[r".*localhost:4040"])
