### PR TITLE
Support skipping a trace in the trace decorator

### DIFF
--- a/opentracing_utils/libs/_requests.py
+++ b/opentracing_utils/libs/_requests.py
@@ -46,17 +46,13 @@ def trace_requests(default_tags=None, set_error_tag=True, mask_url_query=True,
     :param ignore_url_patterns: Ignore tracing for any URL's that match entries in this list
     :type ignore_url_patterns: list
     """
-    def skip_span_matcher(*args, **kwargs):
+    def skip_span_matcher(http_adapter_obj, request, **kwargs):
         if ignore_url_patterns is None:
-            return False
-
-        try:
-            request = [a for a in args if isinstance(a, requests.PreparedRequest)][0]
-        except IndexError:
             return False
 
         if any(re.match(p, request.url) for p in ignore_url_patterns):
             return True
+
         return False
 
     @trace(pass_span=True, tags=default_tags, skip_span=skip_span_matcher)


### PR DESCRIPTION
Adds functionality for the `@trace`-decorator to accept a callable `skip_trace`. This callable
should return a `bool` depending on whether to skip a trace based on some parameters in 
either `*args` or `**kwargs`. For example, when using the `trace_requests=(ignore_url_pattern[..])`, a matcher function is used to validate the `request.url` against any patterns in the list.

Resolves #16 