### PR TITLE
Allow django callables beside string imports

### DIFF
--- a/opentracing_utils/libs/_django.py
+++ b/opentracing_utils/libs/_django.py
@@ -37,10 +37,16 @@ class OpenTracingHttpMiddleware(MiddlewareMixin):
         self._min_error_code = 400 if error_4xx else 500
 
         op_name_str = getattr(settings, 'OPENTRACING_UTILS_OPERATION_NAME_CALLABLE', '')
-        self._op_name_callable = import_string(op_name_str) if op_name_str else None
+        if callable(op_name_str):
+            self._op_name_callable = op_name_str
+        else:
+            self._op_name_callable = import_string(op_name_str) if op_name_str else None
 
         skip_span_str = getattr(settings, 'OPENTRACING_UTILS_SKIP_SPAN_CALLABLE', '')
-        self._skip_span_callable = import_string(skip_span_str) if skip_span_str else None
+        if callable(skip_span_str):
+            self._skip_span_callable = skip_span_str
+        else:
+            self._skip_span_callable = import_string(skip_span_str) if skip_span_str else None
 
     def process_view(self, request, view_func, view_args, view_kwargs):
         if self._skip_span_callable and self._skip_span_callable(request, view_func, view_args, view_kwargs):

--- a/tests/test_django/test_django_middleware.py
+++ b/tests/test_django/test_django_middleware.py
@@ -113,10 +113,11 @@ def test_request_error(client):
 
 
 @pytest.mark.skipif(six.PY2, reason='')
-def test_request_skip_span(client, settings):
+@pytest.mark.parametrize('op_name', ('tests.test_django.test_django_middleware.skip_span', skip_span))
+def test_request_skip_span(client, settings, op_name):
     recorder = get_recorder()
 
-    settings.OPENTRACING_UTILS_SKIP_SPAN_CALLABLE = 'tests.test_django.test_django_middleware.skip_span'
+    settings.OPENTRACING_UTILS_SKIP_SPAN_CALLABLE = op_name
 
     response = client.get('/')
     assert response.content == b'TRACED'
@@ -136,10 +137,11 @@ def test_request_skip_span(client, settings):
 
 
 @pytest.mark.skipif(six.PY2, reason='')
-def test_request_operation_name(client, settings):
+@pytest.mark.parametrize('op_name', ('tests.test_django.test_django_middleware.operation_name', operation_name))
+def test_request_operation_name(client, settings, op_name):
     recorder = get_recorder()
 
-    settings.OPENTRACING_UTILS_OPERATION_NAME_CALLABLE = 'tests.test_django.test_django_middleware.operation_name'
+    settings.OPENTRACING_UTILS_OPERATION_NAME_CALLABLE = op_name
 
     response = client.get('/user')
     assert response.content == b'USER'


### PR DESCRIPTION
Allow django callables beside string imports