### PR TITLE
break reference cycle in inspect_span_from_stack

### DIFF
--- a/opentracing_utils/span.py
+++ b/opentracing_utils/span.py
@@ -78,6 +78,11 @@ def inspect_span_from_stack(depth=100):
 
         frame = frame.f_back
 
+    # delete reference cycle
+    # https://docs.python.org/3/library/inspect.html#the-interpreter-stack
+    del cframe
+    del frame
+
     return span
 
 

--- a/tests/test_span.py
+++ b/tests/test_span.py
@@ -1,3 +1,5 @@
+import gc
+
 import opentracing
 
 from mock import MagicMock
@@ -6,8 +8,11 @@ from opentracing.ext import tags as opentracing_tags
 from basictracer import BasicTracer
 
 
-from opentracing_utils.span import get_new_span, adjust_span, extract_span_from_kwargs, remove_span_from_kwargs
+from opentracing_utils.span import get_new_span, adjust_span, extract_span_from_kwargs, remove_span_from_kwargs, inspect_span_from_stack
 from opentracing_utils.span import DEFAULT_SPAN_ARG_NAME
+
+import pytest
+import six
 
 
 def test_get_new_span():
@@ -87,3 +92,30 @@ def test_remove_span_from_kwargs(monkeypatch):
     clean_kwargs = remove_span_from_kwargs(**kwargs)
 
     assert clean_kwargs == {'not_span': 1, 'also_not_span': 'no span'}
+
+
+@pytest.mark.skipif(six.PY2, reason="gc.get_stats requires >=3.4")
+def test_inspect_span_from_stack_does_not_create_reference_cycle():
+    # inspect_span_from_stack inspects the stack via stack frames. This can
+    # very easily lead to the creation of reference cycles. These are not
+    # free-d using reference counting and therefore the GC needs to clean them
+    # up. If reference cycles are created frequently and therefore the GC runs
+    # frequently, this can have a significant impact on CPU usage and overall
+    # latency.
+    #
+    # This test makes sure that this function doesn't create a reference cycle
+    # by testing whether the GC is able to collect any objects after calling
+    # this function.
+
+    # Run a collection to ensure that all reference cycles that may have been
+    # created up to this point to be collected, so that they don't mess up our
+    # measurement.
+    gc.collect()
+
+    previous_stats = gc.get_stats()
+    inspect_span_from_stack()
+    gc.collect()
+    stats = gc.get_stats()
+
+    for previous_generation, current_generation in zip(previous_stats, stats):
+        assert previous_generation['collected'] == current_generation['collected']

--- a/tests/test_span.py
+++ b/tests/test_span.py
@@ -8,7 +8,10 @@ from opentracing.ext import tags as opentracing_tags
 from basictracer import BasicTracer
 
 
-from opentracing_utils.span import get_new_span, adjust_span, extract_span_from_kwargs, remove_span_from_kwargs, inspect_span_from_stack
+from opentracing_utils.span import (
+    get_new_span, adjust_span, extract_span_from_kwargs, remove_span_from_kwargs,
+    inspect_span_from_stack
+)
 from opentracing_utils.span import DEFAULT_SPAN_ARG_NAME
 
 import pytest


### PR DESCRIPTION
`inspect_span_from_stack` creates a reference cycle due to incorrect usage of `inspect.currentframe` (see the warning in the documentation https://docs.python.org/3/library/inspect.html#the-interpreter-stack).

This issue is inherited by other functions that call it directly or indirectly. Here is a script that gives you some indication of the impact:

```
import gc
from contextlib import contextmanager

from opentracing_utils import trace
from opentracing_utils.span import (
    get_new_span,
    get_parent_span,
    inspect_span_from_stack,
)


@trace()
def foo():
    pass


@contextmanager
def debug_gc():
    gc.collect()
    gc.set_debug(gc.DEBUG_STATS | gc.DEBUG_COLLECTABLE)
    try:
        yield
    finally:
        gc.collect()
        gc.set_debug(0)


def main():
    print("@trace " + "=" * 40)
    with debug_gc():
        foo()
    print("=======" + "=" * 40)

    print("get_new_span " + "=" * 40)
    with debug_gc():
        get_new_span(lambda: None, (), {})
    print("=============" + "=" * 40)

    print("get_parent_span " + "=" * 40)
    with debug_gc():
        get_parent_span()
    print("================" + "=" * 40)

    print("inspect_span_from_stack " + "=" * 40)
    with debug_gc():
        inspect_span_from_stack()
    print("========================" + "=" * 40)


if __name__ == "__main__":
    main()
```

Output:
```
@trace ========================================
gc: collecting generation 2...
gc: objects in each generation: 7 0 45420
gc: objects in permanent generation: 0
gc: collectable <dict 0x109e10e40>
gc: collectable <dict 0x10a74ec80>
gc: collectable <dict 0x109e11ec0>
gc: collectable <frame 0x10b084b80>
gc: collectable <frame 0x109789e40>
gc: collectable <frame 0x7faa93dd3350>
gc: collectable <frame 0x7faa93de0050>
gc: done, 7 unreachable, 0 uncollectable, 0.0079s elapsed
===============================================
get_new_span ========================================
gc: collecting generation 2...
gc: objects in each generation: 6 0 45419
gc: objects in permanent generation: 0
gc: collectable <function 0x10b07b310>
gc: collectable <dict 0x1097be280>
gc: collectable <dict 0x1097302c0>
gc: collectable <frame 0x10b084b80>
gc: collectable <frame 0x109789e40>
gc: collectable <frame 0x7faa93dd3350>
gc: done, 6 unreachable, 0 uncollectable, 0.0104s elapsed
=====================================================
get_parent_span ========================================
gc: collecting generation 2...
gc: objects in each generation: 3 0 45419
gc: objects in permanent generation: 0
gc: collectable <dict 0x109e10e40>
gc: collectable <frame 0x10b084b80>
gc: collectable <frame 0x109789e40>
gc: done, 3 unreachable, 0 uncollectable, 0.0099s elapsed
========================================================
inspect_span_from_stack ========================================
gc: collecting generation 2...
gc: objects in each generation: 1 0 45419
gc: objects in permanent generation: 0
gc: collectable <frame 0x10b084b80>
gc: done, 1 unreachable, 0 uncollectable, 0.0108s elapsed
================================================================
```

In real world applications we are observing 10k objects collected per minute, which leads to hundreds of GC collections per minute. This in turn has a significant impact on CPU usage and latency.

This PR changes `inspect_span_from_stack` so that it uses `inspect.currentframe` in the way recommended by the Python documentation. It also adds a test to verify that this function doesn't create reference cycles.