### PR TITLE
Mention vendor dependencies in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,10 +119,12 @@ OPENTRACING_INSTANA_SERVICE
 
     # Now use the opentracing.tracer
     root_span = opentracing.tracer.start_span(operation_name='root_span')
+Dependency
+~~~~~~~~~~
+Add ``instana`` to the ``dependencies.txt`` of your project.
 
 Jaeger
 ^^^^^^
-
 Config Vars
 ~~~~~~~~~~~
 
@@ -149,7 +151,9 @@ OPENTRACING_JAEGER_SERVICE_NAME
 
     # Now use the opentracing.tracer
     root_span = opentracing.tracer.start_span(operation_name='root_span')
-
+Dependency
+~~~~~~~~~~
+Add ``jaeger_client`` to the ``dependencies.txt`` of your project.
 
 LightStep
 ^^^^^^^^^
@@ -187,7 +191,9 @@ OPENTRACING_LIGHTSTEP_VERBOSITY
 
     # Now use the opentracing.tracer
     root_span = opentracing.tracer.start_span(operation_name='root_span')
-
+Dependency
+~~~~~~~~~~
+Add ``lightstep`` to the ``dependencies.txt`` of your project.
 
 @trace decorator
 ----------------


### PR DESCRIPTION
The libraries of the specific vendors (lightstep, instant, jaeger) are not part of dependencies.txt of opentracing-utils and have to be added to the dependencies of the application which is using opentracing-utils.