### PR TITLE
Add span_extractor argument to requests tracing

### DIFF
--- a/opentracing_utils/libs/_requests.py
+++ b/opentracing_utils/libs/_requests.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 
 def trace_requests(default_tags=None, set_error_tag=True, mask_url_query=True,
-                   mask_url_path=False, ignore_url_patterns=None):
+                   mask_url_path=False, ignore_url_patterns=None, span_extractor=None):
     """Patch requests library with OpenTracing support.
 
     :param default_tags: Default span tags to included with every outgoing request.
@@ -45,6 +45,9 @@ def trace_requests(default_tags=None, set_error_tag=True, mask_url_query=True,
 
     :param ignore_url_patterns: Ignore tracing for any URL's that match entries in this list
     :type ignore_url_patterns: list
+
+    :param span_extractor: Callable to return the parent span.
+    :type span_extractor: Callable[*args, **kwargs]
     """
     def skip_span_matcher(http_adapter_obj, request, **kwargs):
         if ignore_url_patterns is None:
@@ -55,7 +58,7 @@ def trace_requests(default_tags=None, set_error_tag=True, mask_url_query=True,
 
         return False
 
-    @trace(pass_span=True, tags=default_tags, skip_span=skip_span_matcher)
+    @trace(pass_span=True, tags=default_tags, skip_span=skip_span_matcher, span_extractor=span_extractor)
     def requests_send_wrapper(self, request, **kwargs):
         if ignore_url_patterns is not None:
             if any(re.match(pattern, request.url) for pattern in ignore_url_patterns):

--- a/tests/test_requests_with_extractor.py
+++ b/tests/test_requests_with_extractor.py
@@ -1,0 +1,53 @@
+import opentracing
+import requests
+from basictracer import BasicTracer
+from requests.models import Response
+
+from opentracing_utils import trace_requests
+from tests.conftest import Recorder
+
+
+def assert_send_request_mock(resp):
+
+    def send_request_mock(self, request, **kwargs):
+        assert 'ot-tracer-traceid' in request.headers
+        assert 'ot-tracer-spanid' in request.headers
+
+        return resp
+
+    return send_request_mock
+
+
+def test_trace_requests_span_extractor(monkeypatch):
+    resp = Response()
+    resp.status_code = 200
+    resp.url = "http://example.com/"
+
+    recorder = Recorder()
+    t = BasicTracer(recorder=recorder)
+    t.register_required_propagators()
+    opentracing.tracer = t
+
+    top_span = opentracing.tracer.start_span(operation_name='top_span')
+
+    def span_extractor(*args, **kwargs):
+        return top_span
+
+    trace_requests(span_extractor=span_extractor)
+
+    monkeypatch.setattr('opentracing_utils.libs._requests.__requests_http_send',
+                        assert_send_request_mock(resp))
+    # disable getting the span from stack
+    monkeypatch.setattr('opentracing_utils.span.inspect_span_from_stack',
+                        lambda: None)
+
+    response = requests.get("http://example.com/")
+
+    top_span.finish()
+
+    assert len(recorder.spans) == 2
+    assert recorder.spans[0].context.trace_id == top_span.context.trace_id
+    assert recorder.spans[0].parent_id == recorder.spans[1].context.span_id
+    assert recorder.spans[0].operation_name == 'http_send_get'
+    assert recorder.spans[-1].operation_name == 'top_span'
+    assert response.status_code == resp.status_code


### PR DESCRIPTION
We want to use this package to send traces from our services to lightstep. Currently, tracing for the requests library does not support passing a custom span extractor, which I added as part of this PR. 