### PR TITLE
Add scope manager support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -204,11 +204,11 @@ Add ``lightstep`` to the ``dependencies.txt`` of your project.
 
 The ``@trace`` decorator supports OpenTracing ``scope_manager`` API (new in opentracing-utils > 0.21.0).
 
-The order of detecting parent span goes as the following:
+The order of detecting a parent span goes as the following:
 
-1. Detect ``scope_manager`` active span (opentracing.tracer.active_span).
-2. Using ``span_extractor`` if exists.
-3. Detect from passed kwargs.
+1. Using ``span_extractor`` if exists.
+2. Detect from passed kwargs.
+3. Detect ``scope_manager`` active span (opentracing.tracer.active_span).
 4. Detect using call stack frames.
 
 .. code-block:: python
@@ -292,27 +292,6 @@ In case you need to always use the ``scope_manager``, then you can pass ``use_sc
 
         # the child span will depend on the ``scope_manager`` to detect the ``top_span`` as the parent span for the following function call.
         trace_and_detect_parent_scope()
-
-
-There is a caveat with regards to passing a parent span in kwargs:
-
-.. code-block:: python
-
-    @trace()
-    def trace_me(**kwargs):
-        current_span = opentracing.tracer.active_span
-        assert current_span.operation_name == 'trace_me'
-
-
-    with opentracing.tracer.start_active_span('top_span', finish_on_close=True):
-
-        # This span is detached and does not link to ``top_span``.
-        detached_span = opentracing.tracer.start_span('detached_span')
-
-        # @trace will detect ``top_span`` as the parent span as it is active in the scope. The ``detached_span`` passed in the kwargs won't be considered.
-        trace_me(parent_span=detached_span)
-
-        detached_span.finish()
 
 
 Skip Spans
@@ -402,8 +381,6 @@ Generators (yield)
 ^^^^^^^^^^^^^^^^^^
 
 Using generators could get tricky and leads to invalid parent span inspection. It is recommended to pass the span explicitly.
-
-Note: Since detecting parent span using ``scope_manager`` takes precedence over passed span in kwargs, span detection might not work as expected in case ``scope_manager`` is used.
 
 .. code-block:: python
 

--- a/opentracing_utils/decorators.py
+++ b/opentracing_utils/decorators.py
@@ -12,10 +12,10 @@ def trace(component=None, operation_name=None, tags=None, use_follows_from=False
 
     The order of parent span inspection:
 
-    1. Using ``opentracing.tracer.active_span`` managed by the tracer context manager. The new span will be using the
+    1. Using ``span_extractor``.
+    2. Detecting span in kwargs.
+    3. Using ``opentracing.tracer.active_span`` managed by the tracer context manager. The new span will be using the
     scope manager.
-    2. Using ``span_extractor``.
-    3. Detecting span in kwargs.
     4. Using call stack frames inspection.
 
     :param commponent: commponent name.

--- a/opentracing_utils/decorators.py
+++ b/opentracing_utils/decorators.py
@@ -15,8 +15,8 @@ def trace(component=None, operation_name=None, tags=None, use_follows_from=False
     1. Using ``opentracing.tracer.active_span`` managed by the tracer context manager. The new span will be using the
     scope manager.
     2. Using ``span_extractor``.
-    3. Using call stack frames inspection.
-
+    3. Detecting span in kwargs.
+    4. Using call stack frames inspection.
 
     :param commponent: commponent name.
     :type commponent: str

--- a/opentracing_utils/libs/_sqlalchemy.py
+++ b/opentracing_utils/libs/_sqlalchemy.py
@@ -54,7 +54,7 @@ def trace_sqlalchemy(
             parent_span = opentracing.tracer.active_span
             using_scope_manager = True if parent_span else False
         except AttributeError:
-            ...
+            pass
 
         if not parent_span and callable(span_extractor):
             parent_span = span_extractor(conn, cursor, statement, parameters, context, executemany)

--- a/opentracing_utils/libs/_sqlalchemy.py
+++ b/opentracing_utils/libs/_sqlalchemy.py
@@ -10,7 +10,14 @@ from opentracing.ext import tags as ot_tags
 from opentracing_utils.span import get_parent_span
 
 
-def trace_sqlalchemy(operation_name=None, span_extractor=None, set_error_tag=False, skip_span=None, enrich_span=None):
+def trace_sqlalchemy(
+    operation_name=None,
+    span_extractor=None,
+    set_error_tag=False,
+    skip_span=None,
+    enrich_span=None,
+    use_scope_manager=False
+):
     """
     Trace Sqlalchemy database queries.
 
@@ -31,6 +38,9 @@ def trace_sqlalchemy(operation_name=None, span_extractor=None, set_error_tag=Fal
 
     :param enrich_span: Callable to enrich the span with additional data.
     :type enrich_span: Callable[span, conn, cursor, statement, parameters, context, executemany]
+
+    :param use_scope_manager: Always use the scope manager when starting the span.
+    :type use_scope_manager: bool
     """
 
     @listens_for(Engine, 'before_cursor_execute')
@@ -38,9 +48,17 @@ def trace_sqlalchemy(operation_name=None, span_extractor=None, set_error_tag=Fal
         if callable(skip_span) and skip_span(conn, cursor, statement, parameters, context, executemany):
             return
 
-        if callable(span_extractor):
+        parent_span = None
+        using_scope_manager = False
+        try:
+            parent_span = opentracing.tracer.active_span
+            using_scope_manager = True if parent_span else False
+        except AttributeError:
+            ...
+
+        if not parent_span and callable(span_extractor):
             parent_span = span_extractor(conn, cursor, statement, parameters, context, executemany)
-        else:
+        elif not parent_span:
             _, parent_span = get_parent_span()
 
         if context:
@@ -60,11 +78,17 @@ def trace_sqlalchemy(operation_name=None, span_extractor=None, set_error_tag=Fal
                 if callable(enrich_span):
                     enrich_span(query_span, conn, cursor, statement, parameters, context, executemany)
 
+                if use_scope_manager or using_scope_manager:
+                    scope = opentracing.tracer.scope_manager.activate(query_span, finish_on_close=True)
+                    context._query_scope = scope
+
                 context._query_span = query_span
 
     @listens_for(Engine, 'after_cursor_execute')
     def tarce_after_cursor_execute(conn, cursor, statement, parameters, context, executemany):
-        if hasattr(context, '_query_span'):
+        if hasattr(context, '_query_scope'):
+            context._query_scope.close()
+        elif hasattr(context, '_query_span'):
             context._query_span.finish()
 
     @listens_for(Engine, 'handle_error')
@@ -76,4 +100,7 @@ def trace_sqlalchemy(operation_name=None, span_extractor=None, set_error_tag=Fal
             if set_error_tag:
                 context._query_span.set_tag('error', True)
 
+        if hasattr(context, '_query_scope'):
+            context._query_scope.close()
+        else:
             context._query_span.finish()

--- a/opentracing_utils/span.py
+++ b/opentracing_utils/span.py
@@ -37,7 +37,7 @@ def get_new_span(
                 using_scope_manager = True if parent_span else False
             except AttributeError:
                 # Old opentracing lib!
-                ...
+                pass
 
         # Finally, try to inspect call stack frames.
         if not parent_span:

--- a/tests/test_django/app/views.py
+++ b/tests/test_django/app/views.py
@@ -1,5 +1,7 @@
 from django.http import HttpResponse
 
+import opentracing
+
 from opentracing_utils import trace, extract_span_from_django_request, extract_span_from_kwargs
 
 
@@ -25,3 +27,13 @@ def nested(request, *args, **kwargs):
     current_span.set_tag('nested', True)
 
     return HttpResponse('NESTED')
+
+
+@trace(operation_name='nested_scope_call', pass_span=True)
+def nested_scope(request, *args, **kwargs):
+    current_span = opentracing.tracer.active_span
+
+    with opentracing.tracer.start_active_span("child_span", child_of=current_span.context):
+        ...
+
+    return HttpResponse('NESTED SCOPE')

--- a/tests/test_django/app/views.py
+++ b/tests/test_django/app/views.py
@@ -34,6 +34,6 @@ def nested_scope(request, *args, **kwargs):
     current_span = opentracing.tracer.active_span
 
     with opentracing.tracer.start_active_span("child_span", child_of=current_span.context):
-        ...
+        pass
 
     return HttpResponse('NESTED SCOPE')

--- a/tests/test_django/urls.py
+++ b/tests/test_django/urls.py
@@ -8,5 +8,6 @@ urlpatterns = [
     url(r'^user', views.user, name='user'),
     url(r'^error', views.error, name='error'),
     url(r'^bad', views.bad_request, name='bad'),
+    url(r'^nested-scope', views.nested_scope, name='nested_scope'),
     url(r'^nested', views.nested, name='nested'),
 ]


### PR DESCRIPTION
Resolve #54
 
# Changes

Add support for tracer scope manager support introduced in `opentracing==2.0`.

I am not fully decided on the order of detecting parent spans. 
The proposed implementation is the following:

~1. Using ``opentracing.tracer.active_span`` managed by the tracer context manager. The new span will be using the
  scope manager.~
~2. Using ``span_extractor``.~
~3. Detecting span in kwargs.~
~4. Using call stack frames inspection.~


  1. Using ``span_extractor``.
  2. Detecting span in kwargs.
  3. Using ``opentracing.tracer.active_span`` managed by the tracer context manager. The new span will be using the
  scope manager.
  4. Using call stack frames inspection.

as ``span_extractor`` and passing spans in ``kwargs`` is more explicit.

Please let me know what you think.

# Release strategy

We don't have to release a new version right away after merging. We are planning to first test the changes in our production systems, fix any related bugs observed and confirm that no breaking changes are introduced.